### PR TITLE
Bootstrap gall en DD scrapers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea
 *.iws
 *.iml
 *.ipr

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,90 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <dagger.version>2.51.1</dagger.version>
+        <lombok.version>1.18.32</lombok.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.17.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.dagger</groupId>
+            <artifactId>dagger</artifactId>
+            <version>${dagger.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.19.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.23.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.23.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.25.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>com.google.dagger</groupId>
+                                <artifactId>dagger-compiler</artifactId>
+                                <version>${dagger.version}</version>
+                            </path>
+                            <path>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>${lombok.version}</version>
+                            </path>
+                        </annotationProcessorPaths>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
 </project>

--- a/src/main/java/org/vaakbenjetebang/LiquidAssets.java
+++ b/src/main/java/org/vaakbenjetebang/LiquidAssets.java
@@ -1,0 +1,13 @@
+package org.vaakbenjetebang;
+
+import org.vaakbenjetebang.infra.DaggerContainer;
+import org.vaakbenjetebang.scraper.ScraperManager;
+
+import java.util.concurrent.ExecutionException;
+
+public class LiquidAssets {
+    public static void main(String[] args) throws InterruptedException, ExecutionException {
+        ScraperManager scraperManager = DaggerContainer.create().getScraperManager();
+        scraperManager.start();
+    }
+}

--- a/src/main/java/org/vaakbenjetebang/Main.java
+++ b/src/main/java/org/vaakbenjetebang/Main.java
@@ -1,7 +1,0 @@
-package org.vaakbenjetebang;
-
-public class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello world!");
-    }
-}

--- a/src/main/java/org/vaakbenjetebang/infra/Container.java
+++ b/src/main/java/org/vaakbenjetebang/infra/Container.java
@@ -1,0 +1,12 @@
+package org.vaakbenjetebang.infra;
+
+import dagger.Component;
+import org.vaakbenjetebang.scraper.ScraperManager;
+
+import javax.inject.Singleton;
+
+@Singleton
+@Component()
+public interface Container {
+    ScraperManager getScraperManager();
+}

--- a/src/main/java/org/vaakbenjetebang/model/GallWhiskyProduct.java
+++ b/src/main/java/org/vaakbenjetebang/model/GallWhiskyProduct.java
@@ -1,0 +1,29 @@
+package org.vaakbenjetebang.model;
+
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+
+public class GallWhiskyProduct extends WhiskyProduct {
+    public static class GallWhiskyProductDeserializer implements JsonDeserializer<GallWhiskyProduct> {
+        @Override
+        public GallWhiskyProduct deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            JsonObject jsonObject = json.getAsJsonObject();
+
+            String name = jsonObject.get("name").getAsString();
+
+            double price = jsonObject.get("price").getAsDouble();
+            double discount = jsonObject.get("discount").getAsDouble();
+
+            double discountedPrice = price - discount;
+
+            GallWhiskyProduct gallWhiskyProduct = new GallWhiskyProduct();
+            gallWhiskyProduct.setName(name);
+            gallWhiskyProduct.setPrice(price);
+            gallWhiskyProduct.setDiscount(discount);
+            gallWhiskyProduct.setDiscountedPrice(discountedPrice);
+            return gallWhiskyProduct;
+        }
+    }
+}

--- a/src/main/java/org/vaakbenjetebang/model/WhiskyProduct.java
+++ b/src/main/java/org/vaakbenjetebang/model/WhiskyProduct.java
@@ -1,0 +1,16 @@
+package org.vaakbenjetebang.model;
+
+import lombok.Data;
+
+@Data
+public class WhiskyProduct {
+    private String name;
+    private double price;
+    private double discount;
+    private double discountedPrice;
+
+    @Override
+    public String toString() {
+        return String.format("Name: %s. Original price: %.2f. Discounted price: %.2f.", name, price, discountedPrice);
+    }
+}

--- a/src/main/java/org/vaakbenjetebang/scraper/Processor.java
+++ b/src/main/java/org/vaakbenjetebang/scraper/Processor.java
@@ -1,0 +1,9 @@
+package org.vaakbenjetebang.scraper;
+
+import org.vaakbenjetebang.model.WhiskyProduct;
+
+import java.util.List;
+
+public interface Processor<T> {
+    List<WhiskyProduct> process(List<T> elements);
+}

--- a/src/main/java/org/vaakbenjetebang/scraper/Scraper.java
+++ b/src/main/java/org/vaakbenjetebang/scraper/Scraper.java
@@ -1,0 +1,10 @@
+package org.vaakbenjetebang.scraper;
+
+import org.vaakbenjetebang.model.WhiskyProduct;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+public interface Scraper<T> {
+    List<T> scrape() throws InterruptedException, ExecutionException;
+}

--- a/src/main/java/org/vaakbenjetebang/scraper/ScraperManager.java
+++ b/src/main/java/org/vaakbenjetebang/scraper/ScraperManager.java
@@ -1,0 +1,50 @@
+package org.vaakbenjetebang.scraper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.units.qual.A;
+import org.jsoup.nodes.Element;
+import org.openqa.selenium.WebElement;
+import org.vaakbenjetebang.model.WhiskyProduct;
+import org.vaakbenjetebang.scraper.drankdozijn.DrankDozijnWhiskyProcessor;
+import org.vaakbenjetebang.scraper.drankdozijn.DrankDozijnWhiskyScraper;
+import org.vaakbenjetebang.scraper.gall.GallWhiskyProcessor;
+import org.vaakbenjetebang.scraper.gall.GallWhiskyScraper;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+public class ScraperManager {
+    private final static Logger log = LogManager.getLogger();
+    private final Scraper<Element> gallWhiskyScraper;
+    private final Processor<Element> gallWhiskyProcessor;
+    private final Scraper<WebElement> drankDozijnWhiskyScraper;
+    private final Processor<WebElement> drankDozijnWhiskyProcessor;
+    @Inject
+    public ScraperManager(GallWhiskyScraper gallWhiskyScraper, GallWhiskyProcessor gallWhiskyProcessor,
+                          DrankDozijnWhiskyScraper drankDozijnWhiskyScraper, DrankDozijnWhiskyProcessor drankDozijnWhiskyProcessor) {
+        this.gallWhiskyScraper = gallWhiskyScraper;
+        this.gallWhiskyProcessor = gallWhiskyProcessor;
+        this.drankDozijnWhiskyScraper = drankDozijnWhiskyScraper;
+        this.drankDozijnWhiskyProcessor = drankDozijnWhiskyProcessor;
+
+    }
+
+    public void start() throws ExecutionException, InterruptedException {
+        long startTime = System.currentTimeMillis();
+        List<WhiskyProduct> whiskyProducts = new ArrayList<>();
+        List<Element> gallWhiskyElements = gallWhiskyScraper.scrape();
+        List<WhiskyProduct> gallWhiskyProducts = gallWhiskyProcessor.process(gallWhiskyElements);
+        whiskyProducts.addAll(gallWhiskyProducts);
+
+        List<WebElement> drankDozijnWhiskyElements = drankDozijnWhiskyScraper.scrape();
+        List<WhiskyProduct> drankDozijnWhiskyProducts = drankDozijnWhiskyProcessor.process(drankDozijnWhiskyElements);
+        whiskyProducts.addAll(drankDozijnWhiskyProducts);
+
+        long endTime = System.currentTimeMillis();
+        long timeTaken = (endTime - startTime) / 1000;
+        log.info("Successfully scraped and processed {} items. Took ~{} seconds.", whiskyProducts.size(), timeTaken);
+    }
+}

--- a/src/main/java/org/vaakbenjetebang/scraper/drankdozijn/DrankDozijnWhiskyProcessor.java
+++ b/src/main/java/org/vaakbenjetebang/scraper/drankdozijn/DrankDozijnWhiskyProcessor.java
@@ -1,0 +1,58 @@
+package org.vaakbenjetebang.scraper.drankdozijn;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.vaakbenjetebang.model.WhiskyProduct;
+import org.vaakbenjetebang.scraper.Processor;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class DrankDozijnWhiskyProcessor implements Processor<WebElement> {
+
+    private final static Logger log = LogManager.getLogger();
+
+    @Inject
+    public DrankDozijnWhiskyProcessor() {}
+
+    @Override
+    public List<WhiskyProduct> process(List<WebElement> elements) {
+        long startTime = System.currentTimeMillis();
+        List<WhiskyProduct> whiskyProducts = new ArrayList<>();
+        for (WebElement element : elements) {
+            String name = element.findElement(By.className("card-title")).getText();
+            List<WebElement> priceInfo = element.findElements(By.className("price_group"));
+
+            String[] prices = priceInfo.getFirst().getText().split("\n");
+
+            WhiskyProduct whiskyProduct = getWhiskyProduct(prices, name);
+
+            whiskyProducts.add(whiskyProduct);
+        }
+
+        long endTime = System.currentTimeMillis();
+        log.info("Took ~" + ((endTime - startTime) / 1000) + " seconds to process DrankDozijn's entries.");
+        return whiskyProducts;
+    }
+
+    private static WhiskyProduct getWhiskyProduct(String[] prices, String name) {
+        String originalPriceAsString = prices[0].replace("€", "").replace(",", ".");
+        double originalPrice = Double.parseDouble(originalPriceAsString);
+
+        String discountedPriceAsString = prices[1].replace("€", "").replace(",", ".");
+        double discountedPrice = Double.parseDouble(discountedPriceAsString);
+
+        WhiskyProduct whiskyProduct = new WhiskyProduct();
+        whiskyProduct.setName(name);
+
+        whiskyProduct.setPrice(originalPrice);
+        whiskyProduct.setDiscountedPrice(discountedPrice);
+
+        whiskyProduct.setDiscount(originalPrice - discountedPrice);
+        return whiskyProduct;
+    }
+}

--- a/src/main/java/org/vaakbenjetebang/scraper/drankdozijn/DrankDozijnWhiskyScraper.java
+++ b/src/main/java/org/vaakbenjetebang/scraper/drankdozijn/DrankDozijnWhiskyScraper.java
@@ -1,0 +1,78 @@
+package org.vaakbenjetebang.scraper.drankdozijn;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.units.qual.C;
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Wait;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.vaakbenjetebang.model.GallWhiskyProduct;
+import org.vaakbenjetebang.scraper.Scraper;
+
+import javax.inject.Inject;
+import java.time.Duration;
+import java.util.*;
+
+
+public class DrankDozijnWhiskyScraper implements Scraper<WebElement> {
+    private final WebDriver driver;
+    private final Actions actions;
+    private final static Logger log = LogManager.getLogger();
+    private final static String URL = "https://drankdozijn.nl/aanbiedingen/whisky";
+    private final static By CONTINUE_TO_SITE_BUTTON_IDENTIFIER = By.name("naar_drankdozijn");
+    private final static By ALLOW_COOKIE_BUTTON_IDENTIFIER = By.className("cc-allow");
+    private final static By LOAD_MORE_WHISKYS_BUTTON_IDENTIFIER = By.id("morebtn");
+    private final static By WHISKY_PRODUCT_IDENTIFIER = By.className("product");
+    private final static long MS_TO_SLEEP = 200L;
+
+    @Inject
+    public DrankDozijnWhiskyScraper() {
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.addArguments("--headless=new");
+        driver = new ChromeDriver(chromeOptions);
+        actions = new Actions(driver);
+    }
+
+    @Override
+    public List<WebElement> scrape() throws InterruptedException {
+        long startTime = System.currentTimeMillis();
+        driver.get(URL);
+        Wait<WebDriver> wait = new WebDriverWait(driver, Duration.ofSeconds(2));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(CONTINUE_TO_SITE_BUTTON_IDENTIFIER));
+
+        WebElement ageVerifyButton = driver.findElement(CONTINUE_TO_SITE_BUTTON_IDENTIFIER);
+        ageVerifyButton.click();
+
+        wait.until(ExpectedConditions.elementToBeClickable(ALLOW_COOKIE_BUTTON_IDENTIFIER));
+        WebElement cookieConsentButton = driver.findElement(ALLOW_COOKIE_BUTTON_IDENTIFIER);
+        cookieConsentButton.click();
+
+        WebElement loadMoreButton = driver.findElement(LOAD_MORE_WHISKYS_BUTTON_IDENTIFIER);
+        loadMoreButton.click();
+
+        Set<WebElement> articles = new HashSet<>();
+        int oldSize = -1;
+
+        while (articles.size() > oldSize) {
+            oldSize = articles.size();
+
+            actions.sendKeys(Keys.END).perform();
+            Thread.sleep(MS_TO_SLEEP);
+
+            List<WebElement> allCurrentVisibleArticles = driver.findElements(WHISKY_PRODUCT_IDENTIFIER);
+            articles.addAll(allCurrentVisibleArticles);
+            int sizeDifference = articles.size() - oldSize;
+            log.info("Processed {} new items. {} in total", sizeDifference, articles.size());
+        }
+
+        long endTime = System.currentTimeMillis();
+        log.info("Took ~" + ((endTime - startTime) / 1000) + " seconds to scrape DrankDozijn. Found " + articles.size() + " whiskys.");
+        return new ArrayList<>(articles);
+    }
+}

--- a/src/main/java/org/vaakbenjetebang/scraper/gall/GallWhiskyProcessor.java
+++ b/src/main/java/org/vaakbenjetebang/scraper/gall/GallWhiskyProcessor.java
@@ -1,0 +1,39 @@
+package org.vaakbenjetebang.scraper.gall;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Element;
+import org.vaakbenjetebang.model.GallWhiskyProduct;
+import org.vaakbenjetebang.model.WhiskyProduct;
+import org.vaakbenjetebang.scraper.Processor;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GallWhiskyProcessor implements Processor<Element> {
+    private final static Logger log = LogManager.getLogger();
+    private final Gson gson = new GsonBuilder().registerTypeAdapter(GallWhiskyProduct.class, new GallWhiskyProduct.GallWhiskyProductDeserializer()).create();
+
+    @Inject
+    public GallWhiskyProcessor() {}
+
+    @Override
+    public List<WhiskyProduct> process(List<Element> elements) {
+        long startTime = System.currentTimeMillis();
+        List<WhiskyProduct> whiskyProducts = new ArrayList<>();
+        for (Element element : elements) {
+            Attributes attributes = element.attributes();
+            String attributeContent = attributes.get("data-product");
+            if (!attributes.isEmpty()) {
+                whiskyProducts.add(gson.fromJson(attributeContent, GallWhiskyProduct.class));
+            }
+        }
+        long endTime = System.currentTimeMillis();
+        log.info("Took ~" + ((endTime - startTime) / 1000) + " seconds to process Gall's entries.");
+        return whiskyProducts;
+    }
+}

--- a/src/main/java/org/vaakbenjetebang/scraper/gall/GallWhiskyScraper.java
+++ b/src/main/java/org/vaakbenjetebang/scraper/gall/GallWhiskyScraper.java
@@ -1,0 +1,63 @@
+package org.vaakbenjetebang.scraper.gall;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.vaakbenjetebang.scraper.Scraper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import javax.inject.Inject;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+public class GallWhiskyScraper implements Scraper<Element> {
+
+    private final static Logger log = LogManager.getLogger();
+    private final static String GALL_URL = "https://www.gall.nl/whisky/?prefn1=actions&prefv1=Acties%20voor%20Premium%7CActies%20voor%20iedereen";
+    private final static String WHISKY_PRODUCT_CLASS_NAME = "ptile";
+
+    @Inject
+    public GallWhiskyScraper() {}
+
+    @Override
+    public List<Element> scrape() throws InterruptedException, ExecutionException {
+        List<Element> whiskyElements = new ArrayList<>();
+        long startTime = System.currentTimeMillis();
+        HttpClient client = HttpClient.newBuilder().build();
+
+        int start = 0;
+        Elements whiskyElementsPerPage = new Elements();
+        while (start == 0 || !whiskyElementsPerPage.isEmpty()) {
+            String url = GALL_URL + "&start=" + start;
+            Document doc = getDocument(url, client);
+
+            Elements productGrid = doc.getElementsByClass("c-product-grid");
+
+            whiskyElementsPerPage = productGrid.getFirst().getElementsByClass(WHISKY_PRODUCT_CLASS_NAME);
+            whiskyElements.addAll(whiskyElementsPerPage);
+            start += 12;
+        }
+
+        client.close();
+        long endTime = System.currentTimeMillis();
+
+        log.info("Took ~" + ((endTime - startTime) / 1000) + " seconds to scrape Gall & Gall. Found " + whiskyElements.size() + " whiskys.");
+
+        return whiskyElements;
+    }
+
+    private static Document getDocument(String url, HttpClient client) throws InterruptedException, ExecutionException {
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).build();
+        CompletableFuture<String> response = client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply(HttpResponse::body);
+        String body = response.get();
+        return Jsoup.parse(body);
+    }
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/test/java/org/vaakbenjetebang/scraper/drankdozijn/DrankDozijnWhiskyProcessorTest.java
+++ b/src/test/java/org/vaakbenjetebang/scraper/drankdozijn/DrankDozijnWhiskyProcessorTest.java
@@ -1,0 +1,16 @@
+package org.vaakbenjetebang.scraper.drankdozijn;
+
+import org.junit.Test;
+
+public class DrankDozijnWhiskyProcessorTest {
+    private final DrankDozijnWhiskyProcessor drankDozijnWhiskyProcessor = new DrankDozijnWhiskyProcessor();
+
+    @Test
+    public void shouldProcessWebElementsSuccessFully() {
+        // given
+
+        // when
+
+        // then
+    }
+}


### PR DESCRIPTION
This commit adds two scrapers, one for Gall & Gall and one for DrankDozijn. 

This sets up the application to start implementing filtering since there is now data to be filtered on.
DrankDozijn uses Selenium since its content is dynamically loaded, while Gall&Gall uses a simple HttpClient. 
It's important to note that the scraping architecture is just a PoC for now. No parallelism is used in the approach in this commit since this is just a bootstrap. In the future, this will be rewritten.