### PR TITLE
Improve prompt exits

### DIFF
--- a/src/main/java/org/vaakbenjetebang/LiquidAssets.java
+++ b/src/main/java/org/vaakbenjetebang/LiquidAssets.java
@@ -18,8 +18,8 @@ public class LiquidAssets {
             Future<?> prompting = executorService.submit(prompt::startPrompt);
 
             prompting.get();
-            executorService.shutdownNow();
-            scraping.get();
+            scraping.cancel(true);
+            executorService.shutdown();
         }
     }
 }

--- a/src/main/java/org/vaakbenjetebang/userinterface/Prompt.java
+++ b/src/main/java/org/vaakbenjetebang/userinterface/Prompt.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class Prompt {
 
-    private final static long MS_TO_WAIT = 100L;
+    private final static long MS_TO_WAIT = 50L;
     private final static int START_STRING_COLUMN_POSITION = 2;
     private final static int COUNTER_ROW_POSITION = 2;
     private final static int BODY_START_POSITION = 4;


### PR DESCRIPTION
Before, if the prompt was exited, the process would still continue to scrape until the scraping was done. This change exits the scraping process whenever the prompting process is done to ensure that the process closes in its entirety after the user is finished with the program.